### PR TITLE
Updating error in README and possible bug in csv-to-run.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ $ script/compile.sh
 ## Run for testing
 * You can configure workloads and benchmark using config.csv
 ~~~{.sh}
-$ cd test
-
 # Generate tmpfs for untrusted memory
-$ sudo generate_tmpfs.sh
+$ cd script
+$ sudo ./generate_tmpfs.sh
 
 $ cd test 
 $ python3 csv-to-run.py
 
 # Delete tmpfs
-$ sudo delete_tmpfs.sh
+$ cd script
+$ sudo ./delete_tmpfs.sh
 ~~~
 
 ## Authors

--- a/test/csv-to-run.py
+++ b/test/csv-to-run.py
@@ -136,7 +136,7 @@ def ping():
     res = subprocess.run("./ping.txt")
 
 def cleanup():
-    untrusted_mem = 'rm  -f /app/untrusted_memory'.split()
+    untrusted_mem = 'rm  -f /app/untrusted_memory/foo'.split()
     checked_run(untrusted_mem)
 
 
@@ -160,7 +160,7 @@ def run_one_config(config):
     args = config_to_args(config)
     print(args)
     if (is_sgx(config)):
-        untrusted_mem = 'fallocate -l 4G /app/untrusted_memory'.split()
+        untrusted_mem = 'fallocate -l 4G /app/untrusted_memory/foo'.split()
         checked_run(untrusted_mem)
 
     sgxtop_process = start_sgxtop() 


### PR DESCRIPTION
Hi, I found an error in the README, specifically for the "Run for testing" section. It cds into test when it should cd into script instead. Also, it is missing the "./" to run the actual scripts generate_tmpfs.sh and delete_tmpfs.sh. These have been updated in my fork.

Also, I believe there is a possible bug in csv-to-run.py. The rm and fallocate commands on lines 139 and 163 respectively look like they need to have a specific file name within /app/untrusted_memory. Otherwise, they repeatedly throw an error that the directory untrusted_memory cannot be removed until a stack overflow error is thrown. I've updated it by tacking on a specific file foo.