### PR TITLE
Create the output directory if it does not exist

### DIFF
--- a/test/csv-to-run.py
+++ b/test/csv-to-run.py
@@ -112,6 +112,9 @@ def config_to_args(config):
 
 def dump(res, args, config, sgxtop):
     fname = (str(datetime.datetime.now()) + '.txt').replace(" ","-").replace(":","-")
+    # Ensure 'output/' exists
+    if not os.path.exists('output') :
+        os.mkdir('output')
     with open('output/' + fname, 'w') as f:
         f.write('@@start\n')
         f.write(str(args) + '\n\n')


### PR DESCRIPTION
Hi,

I hit this minor issue when following the instructions for running tweezer: if the directory output doesn't exist, the script exits without a clear error or a note in the instructions that one needs to do this step.  This patch creates the output directory.

Thanks!